### PR TITLE
[common] Screen size is auto-determined with SDL 2.0.3

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -62,7 +62,7 @@ SDL2TestApplication::run()
     m_window = SDL_CreateWindow("SDL2TestApplication",
             SDL_WINDOWPOS_CENTERED,
             SDL_WINDOWPOS_CENTERED, 
-            800, 480,
+            0, 0,
             SDL_WINDOW_SHOWN | SDL_WINDOW_OPENGL | SDL_WINDOW_FULLSCREEN);
 
     if (m_window == NULL) {


### PR DESCRIPTION
Upstream changeset: https://hg.libsdl.org/SDL/rev/e33b5f7df761

The nemomobile package is SDL 2.0.3 from upstream plus that single
commit cherry-picked to allow proper operation also on Sailfish OS.
