### PR TITLE
Fix touch input coordinates for SDL 2.0.16

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -3,7 +3,6 @@
  * SDL 2.0 OpenGL ES Test Application
  *
  * Copyright (C) 2013 Jolla Ltd.
- * Contact: Thomas Perl <thomas.perl@jollamobile.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/common.cpp
+++ b/common.cpp
@@ -2,7 +2,7 @@
  *
  * SDL 2.0 OpenGL ES Test Application
  *
- * Copyright (C) 2013 Jolla Ltd.
+ * Copyright (C) 2013-2021 Jolla Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -114,7 +114,11 @@ SDL2TestApplication::run()
                     break;
                 case SDL_FINGERDOWN:
                     touch = new TouchPoint(event.tfinger.fingerId,
+#if SDL_VERSION_ATLEAST(2, 0, 16)
+                            event.tfinger.x * w, event.tfinger.y * h);
+#else
                             event.tfinger.x, event.tfinger.y);
+#endif
                     m_touches.push_back(touch);
                     onPressed(touch);
                     printf("Finger down: (%.2f, %.2f)\n", touch->x, touch->y);
@@ -125,8 +129,13 @@ SDL2TestApplication::run()
                         touch = *it;
                         if (touch->id == event.tfinger.fingerId) {
                             if (event.type == SDL_FINGERMOTION) {
+#if SDL_VERSION_ATLEAST(2, 0, 16)
+                                touch->x = event.tfinger.x * w;
+                                touch->y = event.tfinger.y * h;
+#else
                                 touch->x = event.tfinger.x;
                                 touch->y = event.tfinger.y;
+#endif
                                 printf("finger move: (%.2f, %.2f)\n", touch->x, touch->y);
                             } else {
                                 printf("Finger up: (%.2f, %.2f)\n", touch->x, touch->y);

--- a/common.h
+++ b/common.h
@@ -3,7 +3,6 @@
  * SDL 2.0 OpenGL ES Test Application
  *
  * Copyright (C) 2013 Jolla Ltd.
- * Contact: Thomas Perl <thomas.perl@jollamobile.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/main_gles1_procaddr.cpp
+++ b/main_gles1_procaddr.cpp
@@ -3,7 +3,6 @@
  * SDL 2.0 OpenGL ES Test Application
  *
  * Copyright (C) 2013, 2015 Jolla Ltd.
- * Contact: Thomas Perl <thomas.perl@jolla.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/main_gles2_procaddr.cpp
+++ b/main_gles2_procaddr.cpp
@@ -3,7 +3,6 @@
  * SDL 2.0 OpenGL ES Test Application
  *
  * Copyright (C) 2013, 2015 Jolla Ltd.
- * Contact: Thomas Perl <thomas.perl@jolla.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/main_image.cpp
+++ b/main_image.cpp
@@ -3,7 +3,6 @@
  * SDL 2.0 Image Test Application
  *
  * Copyright (C) 2013 Jolla Ltd.
- * Contact: Thomas Perl <thomas.perl@jollamobile.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/main_joystick.cpp
+++ b/main_joystick.cpp
@@ -3,7 +3,6 @@
  * SDL 2.0 Joystick Test Application
  *
  * Copyright (C) 2014 Jolla Ltd.
- * Contact: Thomas Perl <thomas.perl@jolla.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/main_mixer.cpp
+++ b/main_mixer.cpp
@@ -3,7 +3,6 @@
  * SDL 2.0 Mixer Test Application
  *
  * Copyright (C) 2013 Jolla Ltd.
- * Contact: Thomas Perl <thomas.perl@jollamobile.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/main_opengles1.cpp
+++ b/main_opengles1.cpp
@@ -3,7 +3,6 @@
  * SDL 2.0 OpenGL ES Test Application
  *
  * Copyright (C) 2013 Jolla Ltd.
- * Contact: Thomas Perl <thomas.perl@jollamobile.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/main_opengles2.cpp
+++ b/main_opengles2.cpp
@@ -3,7 +3,6 @@
  * SDL 2.0 OpenGL ES Test Application
  *
  * Copyright (C) 2013 Jolla Ltd.
- * Contact: Thomas Perl <thomas.perl@jollamobile.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/main_renderer.cpp
+++ b/main_renderer.cpp
@@ -3,7 +3,6 @@
  * SDL 2.0 Image Test Application
  *
  * Copyright (C) 2013 Jolla Ltd.
- * Contact: Thomas Perl <thomas.perl@jollamobile.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/main_ttf.cpp
+++ b/main_ttf.cpp
@@ -3,7 +3,6 @@
  * SDL 2.0 TTF Test Application
  *
  * Copyright (C) 2013 Jolla Ltd.
- * Contact: Thomas Perl <thomas.perl@jollamobile.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/procaddr_helper.h
+++ b/procaddr_helper.h
@@ -4,7 +4,6 @@
  * SDL 2.0 OpenGL ES Test Application
  *
  * Copyright (C) 2015 Jolla Ltd.
- * Contact: Thomas Perl <thomas.perl@jolla.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/rpm/sdl2-opengles-test.spec
+++ b/rpm/sdl2-opengles-test.spec
@@ -2,10 +2,8 @@ Name:		sdl2-opengles-test
 Version:	1.0.8
 Release:	1
 Summary:	OpenGL ES 1.1 and 2.0 test applications (using SDL2)
-
-Group:		System/GUI/Other
 License:	MIT
-URL:		https://github.com/thp/sdl2-opengles-test
+URL:		https://github.com/mer-qa/sdl2-opengles-test
 Source0:	%{name}-%{version}.tar.bz2
 BuildRequires:	pkgconfig(sdl2)
 BuildRequires:	pkgconfig(egl)
@@ -22,16 +20,16 @@ This application is used to test OpenGL ES 1.1 and 2.0 rendering
 using SDL 2.0 under Wayland. Also tested: multi-touch input.
 
 %prep
-%setup -q
+%autosetup
 
 %build
-make
+%make_build
 
 %install
 %make_install
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/*
-/usr/share/applications/*.desktop
-/usr/share/%(name)/*
+%{_bindir}/*
+%{_datadir}/applications/*.desktop
+%{_datadir}/%(name)/*


### PR DESCRIPTION
Cleanup spec. Cleanup copyright headers. Requires https://github.com/sailfishos/libsdl/pull/1.