### PR TITLE
Add support for reporting display events. Fix sandboxing.

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -108,6 +108,10 @@ SDL2TestApplication::run()
                 case SDL_QUIT:
                     quit = 1;
                     break;
+                case SDL_DISPLAYEVENT:
+                    printf("Display: %u event: %d (%d)\n", event.display.display,
+                            event.window.event, event.display.data1);
+                    break;
                 case SDL_WINDOWEVENT:
                     printf("Window event: %d (%d, %d)\n", event.window.event,
                             event.window.data1, event.window.data2);

--- a/main_image.cpp
+++ b/main_image.cpp
@@ -141,8 +141,8 @@ SDL2TestApplicationImage::initGL()
         return;
     }
 
-    texture_from_png = textureFromImage(DATADIR "SDL_logo.png", TextureImage::RGBA);
-    texture_from_jpg = textureFromImage(DATADIR "sailfish-site-bg_small.jpg", TextureImage::RGB);
+    texture_from_png = textureFromImage(DATADIR_IMAGE "SDL_logo.png", TextureImage::RGBA);
+    texture_from_jpg = textureFromImage(DATADIR_IMAGE "sailfish-site-bg_small.jpg", TextureImage::RGB);
 }
 
 void

--- a/main_image.cpp
+++ b/main_image.cpp
@@ -193,9 +193,9 @@ SDL2TestApplicationImage::renderGL()
     glBindTexture(GL_TEXTURE_2D, texture_from_jpg);
     float vtxcoords[] = {
         0, 0,
-        width, 0,
-        0, height,
-        width, height,
+        (float)width, 0,
+        0, (float)height,
+        (float)width, (float)height,
     };
     float texcoords[] = { 0, 0, 1, 0, 0, 1, 1, 1 };
 

--- a/main_joystick.cpp
+++ b/main_joystick.cpp
@@ -127,7 +127,7 @@ SDL2TestApplicationJoystick::initGL()
     glGenTextures(1, &texture);
 
     int size = 30;
-    font = TTF_OpenFont(DATADIR "SourceSansPro-Regular.ttf", size);
+    font = TTF_OpenFont(DATADIR_JOYSTICK "SourceSansPro-Regular.ttf", size);
 
     // Initialize the joystick subsystem
     SDL_InitSubSystem(SDL_INIT_JOYSTICK);

--- a/main_joystick.cpp
+++ b/main_joystick.cpp
@@ -163,7 +163,10 @@ SDL2TestApplicationJoystick::renderText(float x, float y, const char *fmt, ...)
     va_start(args, fmt);
 
     char *text;
-    vasprintf(&text, fmt, args);
+    if (vasprintf(&text, fmt, args) < 0) {
+        return 0;
+    }
+
     ttf_render_text(font, &textsize, text);
     free(text);
 
@@ -237,7 +240,7 @@ SDL2TestApplicationJoystick::renderGL()
 
         TEXTOUT("---");
         for (int i=0; i<SDL_JoystickNumHats(joy); i++) {
-            char *hatState = "<unknown>";
+            const char *hatState;
 
 #define CASE_HAT_STATE(x) case x: hatState = #x; break
 
@@ -251,6 +254,9 @@ SDL2TestApplicationJoystick::renderGL()
                 CASE_HAT_STATE(SDL_HAT_RIGHTDOWN);
                 CASE_HAT_STATE(SDL_HAT_LEFTUP);
                 CASE_HAT_STATE(SDL_HAT_LEFTDOWN);
+                default:
+                    hatState = "<unknown>";
+                    break;
             }
 
 #undef CASE_HAT_STATE

--- a/main_mixer.cpp
+++ b/main_mixer.cpp
@@ -128,7 +128,7 @@ SDL2TestApplicationMixer::initGL()
         g_main_context_iteration(NULL, true);
     }
 
-    sample = Mix_LoadWAV(DATADIR "95328__ramas26__c.ogg");
+    sample = Mix_LoadWAV(DATADIR_MIXER "95328__ramas26__c.ogg");
     if (sample == NULL) {
         printf("Mix_LoadWAV: %s\n", Mix_GetError());
         exit(1);

--- a/main_opengles2.cpp
+++ b/main_opengles2.cpp
@@ -145,9 +145,9 @@ SDL2TestApplicationGLESv2::resizeGL(int width, int height)
 
     // Transposed
     float projection[] = {
-        2.0 / (right - left), 0.0, 0.0, 0.0,
-        0.0, 2.0 / (top - bottom), 0.0, 0.0,
-        0.0, 0.0, -2.0 / (farVal - nearVal), 0.0,
+        2.0f / (right - left), 0.0f, 0.0f, 0.0f,
+        0.0f, 2.0f / (top - bottom), 0.0f, 0.0f,
+        0.0f, 0.0f, -2.0f / (farVal - nearVal), 0.0f,
         tx, ty, tz, 1.0,
     };
 

--- a/main_ttf.cpp
+++ b/main_ttf.cpp
@@ -122,7 +122,7 @@ SDL2TestApplicationTTF::initGL()
     glGenTextures(1, &texture);
 
     int size = 30;
-    font = TTF_OpenFont(DATADIR "SourceSansPro-Regular.ttf", size);
+    font = TTF_OpenFont(DATADIR_TTF "SourceSansPro-Regular.ttf", size);
 }
 
 void

--- a/makefile
+++ b/makefile
@@ -4,15 +4,21 @@ PACKAGE := sdl2-opengles-test
 SOURCES := $(wildcard main_*.cpp)
 TARGETS := $(patsubst main_%.cpp,sdl2_%_test,$(SOURCES))
 DESKTOPS := $(patsubst %,%.desktop,$(TARGETS))
-DATA_FILES := $(wildcard images/* fonts/* sounds/*)
 
 DESTDIR ?=
 PREFIX ?= /usr
 
-DATADIR := $(PREFIX)/share/$(PACKAGE)/
+BASEDATADIR := $(PREFIX)/share/
+DATADIR_IMAGE := $(BASEDATADIR)/sdl2_image_test/
+DATADIR_JOYSTICK := $(BASEDATADIR)/sdl2_joystick_test/
+DATADIR_MIXER := $(BASEDATADIR)/sdl2_mixer_test/
+DATADIR_TTF := $(BASEDATADIR)/sdl2_ttf_test/
 
 CXXFLAGS ?= -g
-CXXFLAGS += -DDATADIR=\"$(DATADIR)\"
+CXXFLAGS += -DDATADIR_IMAGE=\"$(DATADIR_IMAGE)\"\
+            -DDATADIR_JOYSTICK=\"$(DATADIR_JOYSTICK)\"\
+            -DDATADIR_MIXER=\"$(DATADIR_MIXER)\"\
+            -DDATADIR_TTF=\"$(DATADIR_TTF)\"
 
 all: $(TARGETS)
 
@@ -46,10 +52,16 @@ sdl2_renderer_test: main_renderer.cpp common.cpp
 install: $(TARGETS) $(DESKTOPS)
 	install -d $(DESTDIR)$(PREFIX)/bin/
 	install -d $(DESTDIR)$(PREFIX)/share/applications/
-	install -d $(DESTDIR)$(DATADIR)
+	install -d $(DESTDIR)$(DATADIR_IMAGE)
+	install -d $(DESTDIR)$(DATADIR_JOYSTICK)
+	install -d $(DESTDIR)$(DATADIR_MIXER)
+	install -d $(DESTDIR)$(DATADIR_TTF)
 	install -m755 $(TARGETS) $(DESTDIR)$(PREFIX)/bin/
 	install -m644 $(DESKTOPS) $(DESTDIR)$(PREFIX)/share/applications/
-	install -m644 $(DATA_FILES) $(DESTDIR)$(DATADIR)
+	install -m644 images/* $(DESTDIR)$(DATADIR_IMAGE)
+	install -m644 fonts/* $(DESTDIR)$(DATADIR_JOYSTICK)
+	install -m644 sounds/* $(DESTDIR)$(DATADIR_MIXER)
+	install -m644 fonts/* $(DESTDIR)$(DATADIR_TTF)
 
 clean:
 	rm -f $(TARGETS)

--- a/rpm/sdl2-opengles-test.spec
+++ b/rpm/sdl2-opengles-test.spec
@@ -32,4 +32,4 @@ using SDL 2.0 under Wayland. Also tested: multi-touch input.
 %defattr(-,root,root,-)
 %{_bindir}/*
 %{_datadir}/applications/*.desktop
-%{_datadir}/%(name)/*
+%{_datadir}/sdl2_*_test


### PR DESCRIPTION
For easier testing of display orientation support added to wayland backend in SDL 2.0.18. Silence build warnings.